### PR TITLE
Add portfolio and earnings scanner

### DIFF
--- a/quant_dashboard/README.md
+++ b/quant_dashboard/README.md
@@ -10,6 +10,9 @@ This Streamlit application provides an interactive interface for running a simpl
 - Train a logistic regression model to predict next day returns
 - Backtest the resulting signals and display performance metrics
 - Visualize price series, signals, drawdowns and feature importances
+- Upload portfolio history to view cumulative returns, Sharpe ratio and
+  drawdowns
+- Scan tickers for upcoming earnings and display volatility metrics
 
 ## Usage
 

--- a/quant_dashboard/app.py
+++ b/quant_dashboard/app.py
@@ -7,45 +7,70 @@ from .features import add_features
 from .regime import detect_regime
 from .model import train_model, generate_signals
 from .backtest import backtest
+from .portfolio import compute_stats
+from .options_scanner import scan as scan_earnings
 
 
 st.title("Quant Dashboard")
 
-with st.sidebar:
-    ticker = st.text_input("Ticker", value="SPY")
-    start = st.date_input("Start Date", value=pd.to_datetime("2018-01-01"))
-    end = st.date_input("End Date", value=pd.to_datetime("2024-01-01"))
-    threshold = st.slider("Signal Threshold", 0.5, 0.7, value=0.55, step=0.01)
-    run = st.button("Run Backtest")
+tab_bt, tab_port, tab_opts = st.tabs(["Backtest", "Portfolio", "Earnings Scanner"])
 
-if run:
-    data = load_data(ticker, start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d"))
-    data = add_features(data)
-    data["regime"] = detect_regime(data)
-    model, train_info, importance = train_model(data)
-    signals = generate_signals(model, data, threshold)
-    stats, cum, dd = backtest(data["Close"], signals)
+with tab_bt:
+    with st.sidebar:
+        ticker = st.text_input("Ticker", value="SPY")
+        start = st.date_input("Start Date", value=pd.to_datetime("2018-01-01"))
+        end = st.date_input("End Date", value=pd.to_datetime("2024-01-01"))
+        threshold = st.slider("Signal Threshold", 0.5, 0.7, value=0.55, step=0.01)
+        run = st.button("Run Backtest")
 
-    st.subheader("Price and Signals")
-    fig, ax = plt.subplots()
-    ax.plot(data.index, data["Close"], label="Close")
-    ax.plot(data.index, data["sma_fast"], label="SMA20", alpha=0.5)
-    ax.plot(data.index, data["sma_slow"], label="SMA50", alpha=0.5)
-    ax.scatter(data.index[signals == 1], data["Close"][signals == 1], marker="^", color="green")
-    ax.scatter(data.index[signals == -1], data["Close"][signals == -1], marker="v", color="red")
-    ax.legend()
-    st.pyplot(fig)
+    if run:
+        data = load_data(ticker, start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d"))
+        data = add_features(data)
+        data["regime"] = detect_regime(data)
+        model, train_info, importance = train_model(data)
+        signals = generate_signals(model, data, threshold)
+        stats, cum, dd = backtest(data["Close"], signals)
 
-    st.subheader("Backtest Performance")
-    st.table(stats)
-    fig2, ax2 = plt.subplots()
-    ax2.plot(cum.index, cum, label="Equity Curve")
-    ax2.fill_between(dd.index, dd, color="red", alpha=0.3, label="Drawdown")
-    ax2.legend()
-    st.pyplot(fig2)
+        st.subheader("Price and Signals")
+        fig, ax = plt.subplots()
+        ax.plot(data.index, data["Close"], label="Close")
+        ax.plot(data.index, data["sma_fast"], label="SMA20", alpha=0.5)
+        ax.plot(data.index, data["sma_slow"], label="SMA50", alpha=0.5)
+        ax.scatter(data.index[signals == 1], data["Close"][signals == 1], marker="^", color="green")
+        ax.scatter(data.index[signals == -1], data["Close"][signals == -1], marker="v", color="red")
+        ax.legend()
+        st.pyplot(fig)
 
-    st.subheader("Feature Importance")
-    st.bar_chart(importance.sort_values())
+        st.subheader("Backtest Performance")
+        st.table(stats)
+        fig2, ax2 = plt.subplots()
+        ax2.plot(cum.index, cum, label="Equity Curve")
+        ax2.fill_between(dd.index, dd, color="red", alpha=0.3, label="Drawdown")
+        ax2.legend()
+        st.pyplot(fig2)
 
-    st.subheader("Model Prediction Accuracy")
-    st.write(train_info["actual"].eq(train_info["prob"] > 0.5).mean())
+        st.subheader("Feature Importance")
+        st.bar_chart(importance.sort_values())
+
+        st.subheader("Model Prediction Accuracy")
+        st.write(train_info["actual"].eq(train_info["prob"] > 0.5).mean())
+
+with tab_port:
+    st.write("Upload a CSV with Date and Value columns to view portfolio metrics.")
+    file = st.file_uploader("Portfolio CSV", type="csv")
+    if file is not None:
+        port_df = pd.read_csv(file, parse_dates=["Date"])
+        stats, equity, dd = compute_stats(port_df)
+        st.table(stats)
+        fig, ax = plt.subplots()
+        ax.plot(equity.index, equity, label="Equity Curve")
+        ax.fill_between(dd.index, dd, color="red", alpha=0.3, label="Drawdown")
+        ax.legend()
+        st.pyplot(fig)
+
+with tab_opts:
+    tickers = st.text_input("Tickers (comma separated)", value="AAPL,MSFT")
+    if st.button("Scan Earnings"):
+        tick_list = [t.strip().upper() for t in tickers.split(",") if t.strip()]
+        results = scan_earnings(tick_list)
+        st.dataframe(results)

--- a/quant_dashboard/options_scanner.py
+++ b/quant_dashboard/options_scanner.py
@@ -1,0 +1,89 @@
+import pandas as pd
+import numpy as np
+import yfinance as yf
+
+
+def _term_structure_slope(ticker: str) -> float | None:
+    """Return slope between front month and 45-day implied vol using options data.
+
+    This function relies on yfinance and will return ``None`` if data
+    cannot be fetched.
+    """
+    try:
+        tk = yf.Ticker(ticker)
+        expirations = tk.options
+        if not expirations:
+            return None
+        # find nearest and 45d expirations
+        dates = pd.to_datetime(expirations)
+        today = pd.Timestamp.today().normalize()
+        front = dates[dates >= today]
+        if front.empty:
+            return None
+        near_exp = front.min()
+        target = today + pd.Timedelta(days=45)
+        near_45 = front[(front - target).abs().argsort()].iloc[0]
+
+        def iv_atm(exp):
+            opt = tk.option_chain(exp)
+            calls = opt.calls
+            if calls.empty:
+                return None
+            atm = calls.iloc[(calls["strike"] - tk.history(period="1d")["Close"].iloc[-1]).abs().argmin()]
+            return atm.get("impliedVolatility")
+
+        iv_near = iv_atm(near_exp.strftime("%Y-%m-%d"))
+        iv_45 = iv_atm(near_45.strftime("%Y-%m-%d"))
+        if iv_near is None or iv_45 is None:
+            return None
+        return iv_near - iv_45
+    except Exception:
+        return None
+
+
+def _avg_volume(ticker: str) -> float | None:
+    """Return 30-day average volume prior to today."""
+    try:
+        hist = yf.download(ticker, period="60d", progress=False)
+        return hist["Volume"].iloc[-30:].mean()
+    except Exception:
+        return None
+
+
+def _iv30_rv30(ticker: str) -> float | None:
+    """Return ratio of 30-day implied volatility to realized volatility."""
+    try:
+        tk = yf.Ticker(ticker)
+        iv = tk.info.get("impliedVolatility")
+        if iv is None:
+            return None
+        hist = tk.history(period="60d")
+        rv = hist["Close"].pct_change().rolling(30).std().iloc[-1] * np.sqrt(252)
+        return iv / rv if rv != 0 else None
+    except Exception:
+        return None
+
+
+def scan(tickers: list[str]) -> pd.DataFrame:
+    """Scan tickers for upcoming earnings and compute metrics."""
+    rows = []
+    for t in tickers:
+        slope = _term_structure_slope(t)
+        vol = _avg_volume(t)
+        ratio = _iv30_rv30(t)
+        if None in (slope, vol, ratio):
+            rec = "Avoid"
+        elif slope < 0 and ratio > 1 and vol > 0:
+            rec = "Recommended"
+        elif slope < 0 or ratio > 1:
+            rec = "Consider"
+        else:
+            rec = "Avoid"
+        rows.append({
+            "Ticker": t,
+            "Term Structure Slope": slope,
+            "Avg Volume": vol,
+            "IV30/RV30": ratio,
+            "Recommendation": rec,
+        })
+    return pd.DataFrame(rows)

--- a/quant_dashboard/portfolio.py
+++ b/quant_dashboard/portfolio.py
@@ -1,0 +1,38 @@
+import pandas as pd
+import numpy as np
+
+
+def compute_stats(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.Series, pd.Series]:
+    """Compute risk statistics for a portfolio value series.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame with a ``Date`` column and ``Value`` column representing
+        portfolio value over time.
+
+    Returns
+    -------
+    stats : pd.DataFrame
+        Table of cumulative return, annualized return, Sharpe ratio and
+        maximum drawdown.
+    equity_curve : pd.Series
+        Cumulative growth of $1 invested in the portfolio.
+    drawdown : pd.Series
+        Drawdown series.
+    """
+    df = df.sort_values("Date").set_index("Date")
+    returns = df["Value"].pct_change().dropna()
+    equity_curve = (1 + returns).cumprod()
+    drawdown = equity_curve / equity_curve.cummax() - 1
+
+    ann_return = equity_curve.iloc[-1] ** (252 / len(equity_curve)) - 1 if len(equity_curve) > 0 else 0
+    sharpe = np.sqrt(252) * returns.mean() / returns.std(ddof=0) if returns.std(ddof=0) != 0 else np.nan
+    stats = pd.DataFrame({
+        "Cumulative Return": equity_curve.iloc[-1] - 1,
+        "Annualized Return": ann_return,
+        "Sharpe": sharpe,
+        "Max Drawdown": drawdown.min(),
+    }, index=[0])
+
+    return stats, equity_curve, drawdown


### PR DESCRIPTION
## Summary
- extend Streamlit dashboard with tabs for backtest, portfolio upload, and earnings scan
- support portfolio metrics via new `portfolio.py`
- add options earnings scanner utilities
- document new features in README

## Testing
- `python -m py_compile quant_dashboard/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6862b5ed8e30832d90e467b78daa2887